### PR TITLE
Fix README layout lab filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ Implementation notes and code for the **five lab assignments** of MIT 6.5940 �
 
 ```text
 .
-├── lab1.ipynb     # Fine-grained Pruning & Channel Pruning
-├── lab2.ipynb     # K-Means Quantization & Linear Quantization
-├── lab3.ipynb     # differentiable NAS & hardware‑aware search
-├── lab4.ipynb     # sparse / quant LLM, KV cache sharing
-├── lab5.ipynb     # run Llama‑2‑7B on laptop CPU/GPU
+├── Lab1.ipynb     # Fine-grained Pruning & Channel Pruning
+├── Lab2.ipynb     # K-Means Quantization & Linear Quantization
+├── Lab3.ipynb     # differentiable NAS & hardware‑aware search
+├── Lab4.ipynb     # sparse / quant LLM, KV cache sharing
+├── Lab5.ipynb     # run Llama‑2‑7B on laptop CPU/GPU
 └── README.md
 ```
 


### PR DESCRIPTION
## Summary
- update README repository layout to match Lab1-5.ipynb file names

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68431251e3548322b63b5e20df7466f6